### PR TITLE
Support multiple chip processes and chip detection

### DIFF
--- a/lib/rfm69.ex
+++ b/lib/rfm69.ex
@@ -1,7 +1,8 @@
 defmodule RFM69 do
   use Bitwise
 
-  @device RFM69.Device
+  alias RFM69.Configuration
+
   @moduledoc false
   @fifo_size 66
   @transfer_sleep trunc(@fifo_size / 4)
@@ -9,54 +10,59 @@ defmodule RFM69 do
   @doc """
   Sets the base frequency of the RFM69 chip in MHz
   """
-  @spec set_base_frequency(pos_integer) :: {:ok}
-  def set_base_frequency(mhz) do
-    @device.write_frequency(trunc(mhz * 1_000_000))
+  @frf_location 0x07
+  @spec set_base_frequency(RFM69.Device.t, pos_integer) :: {:ok}
+  def set_base_frequency(%{name: name}, mhz) do
+    frequency_in_hz = trunc(mhz * 1_000_000)
+    register_values = Configuration.frequency_to_registers(frequency_in_hz)
+    register_bytes = <<register_values::24>>
+    :ok = GenServer.call(name, {:write_burst, @frf_location, register_bytes})
+    {:ok}
   end
 
   @doc """
   reads a frame of binary data from the chip's FIFO queue
   """
-  @spec read(non_neg_integer) :: {:ok, %{data: binary, rssi: number}} | {:error, any()}
-  def read(timeout_ms) do
-    set_auto_modes([])
-    set_mode(:receiver)
-    @device.await_interrupt()
+  @spec read(RFM69.Device.t, non_neg_integer) :: {:ok, %{data: binary, rssi: number}} | {:error, any()}
+  def read(%{name: name}, timeout_ms) do
+    set_auto_modes(name, [])
+    set_mode(name, :receiver)
+    GenServer.call(name, {:await_interrupt})
 
     result =
       receive do
         {:ok, :interrupt_received} ->
-          rssi = read_rssi()
-          bytes = read_until_null(<<>>)
+          rssi = read_rssi(name)
+          bytes = read_until_null(name, <<>>)
           {:ok, %{data: bytes, rssi: rssi}}
       after
         timeout_ms ->
-          @device.cancel_interrupt()
+          GenServer.call(name, {:cancel_interrupt})
           {:error, :timeout}
       end
 
-    set_mode(:sleep)
+    set_mode(name, :sleep)
     result
   end
 
   @doc """
   Writes a frame of binary data to the FIFO queue
   """
-  @spec write(binary, pos_integer, non_neg_integer, non_neg_integer, boolean) :: {:ok, <<>>}
-  def write(packet_bytes, repetitions, repetition_delay, timeout_ms, initial \\ true) do
+  @spec write(RFM69.Device.t, binary, pos_integer, non_neg_integer, non_neg_integer, boolean) :: {:ok, <<>>}
+  def write(chip = %{name: name}, packet_bytes, repetitions, repetition_delay, timeout_ms, initial \\ true) do
     if initial == true do
-      clear_fifo()
-      set_mode(:standby)
+      clear_fifo(name)
+      set_mode(name, :standby)
     end
 
     case repetitions do
       r when r >= 1 ->
-        _write(packet_bytes, timeout_ms)
+        _write(name, packet_bytes, timeout_ms)
         :timer.sleep(repetition_delay)
-        write(packet_bytes, repetitions - 1, repetition_delay, timeout_ms, false)
+        write(chip, packet_bytes, repetitions - 1, repetition_delay, timeout_ms, false)
 
       0 ->
-        set_mode(:sleep)
+        set_mode(name, :sleep)
         {:ok, ""}
     end
   end
@@ -64,62 +70,72 @@ defmodule RFM69 do
   @doc """
   Writes the given binary data to the FIFO queue and waits for the response.
   """
-  @spec write_and_read(binary, non_neg_integer) :: {:ok, %{data: binary, rssi: number}} | {:error, any()}
-  def write_and_read(packet_bytes, timeout_ms) do
-    write(packet_bytes, 1, 0, timeout_ms)
-    read(timeout_ms)
+  @spec write_and_read(RFM69.Device.t, binary, non_neg_integer) :: {:ok, %{data: binary, rssi: number}} | {:error, any()}
+  def write_and_read(chip, packet_bytes, timeout_ms) do
+    write(chip, packet_bytes, 1, 0, timeout_ms)
+    read(chip, timeout_ms)
   end
 
-  @spec clear_buffers() :: :ok
-  def clear_buffers do
-    clear_fifo()
+  @spec clear_buffers(RFM69.Device.t) :: :ok
+  def clear_buffers(%{name: name}) do
+    clear_fifo(name)
   end
 
-  defp _write(packet_bytes, _timeout_ms) do
+  @doc """
+  Writes a full configuration struct to the registers on the chip.
+  """
+  @configuration_start 0x01
+  @spec write_configuration(RFM69.Device.t, RFM69.Configuration.t) :: :ok
+  def write_configuration(%{name: name}, rf_config = %RFM69.Configuration{}) do
+    configuration_bytes = Configuration.to_binary(rf_config)
+    :ok = GenServer.call(name, {:write_burst, @configuration_start, configuration_bytes})
+  end
+
+  defp _write(name, packet_bytes, _timeout_ms) do
     modes = [:enter_condition_fifo_not_empty, :exit_condition_fifo_empty, :intermediate_mode_tx]
-    set_auto_modes(modes)
-    transmit(packet_bytes, @fifo_size)
+    set_auto_modes(name, modes)
+    transmit(name, packet_bytes, @fifo_size)
   end
 
-  defp read_until_null(data) do
-    case @device.read_single(0x00) do
-      {:ok, 0x00} -> data
-      {:ok, byte} -> read_until_null(data <> <<byte::8>>)
+  defp read_until_null(name, data) do
+    case GenServer.call(name, {:read_burst, 0x00, 1}) do
+      {:ok, <<0x00::8>>} -> data
+      {:ok, <<byte::8>>} -> read_until_null(name, data <> <<byte::8>>)
     end
   end
 
-  defp transmit(bytes, available_buffer_bytes) when byte_size(bytes) <= available_buffer_bytes do
-    _transmit(bytes)
-    wait_for_mode(:standby)
+  defp transmit(name, bytes, available_buffer_bytes) when byte_size(bytes) <= available_buffer_bytes do
+    _transmit(name, bytes)
+    wait_for_mode(name, :standby)
   end
 
-  defp transmit(bytes, available_buffer_bytes) do
+  defp transmit(name, bytes, available_buffer_bytes) do
     <<transmit_now::binary-size(available_buffer_bytes), transmit_later::binary>> = bytes
-    available_buffer_bytes = _transmit(transmit_now)
-    transmit(transmit_later, available_buffer_bytes)
+    available_buffer_bytes = _transmit(name, transmit_now)
+    transmit(name, transmit_later, available_buffer_bytes)
   end
 
-  defp _transmit(bytes) do
-    @device.write_burst(0x00, bytes)
+  defp _transmit(name, bytes) do
+    GenServer.call(name, {:write_burst, 0x00, bytes})
     :timer.sleep(@transfer_sleep)
-    wait_for_buffer_to_become_available()
+    wait_for_buffer_to_become_available(name)
   end
 
   @reg_irq_flags2 0x28
   @fifo_overrun 0x10
-  defp clear_fifo do
-    @device.write_single(@reg_irq_flags2, @fifo_overrun)
+  defp clear_fifo(name) do
+    GenServer.call(name, {:write_burst, @reg_irq_flags2, <<@fifo_overrun::8>>})
   end
 
   @fifo_level 0x20
-  defp fifo_threshold_exceeded?() do
-    {:ok, byte} = @device.read_single(@reg_irq_flags2)
+  defp fifo_threshold_exceeded?(name) do
+    {:ok, <<byte::8>>} = GenServer.call(name, {:read_burst, @reg_irq_flags2, 1})
     (byte &&& @fifo_level) != 0x00
   end
 
-  defp wait_for_buffer_to_become_available do
-    case fifo_threshold_exceeded?() do
-      true -> wait_for_buffer_to_become_available()
+  defp wait_for_buffer_to_become_available(name) do
+    case fifo_threshold_exceeded?(name) do
+      true -> wait_for_buffer_to_become_available(name)
       false -> nil
     end
   end
@@ -137,32 +153,32 @@ defmodule RFM69 do
     transmitter:   0x0C,
     receiver:      0x10
   }
-  defp set_mode(mode) do
+  defp set_mode(name, mode) do
     mode = Map.get(@modes, mode)
-    current_mode = get_mode()
+    current_mode = get_mode(name)
 
     case mode do
       ^current_mode -> true
       _ ->
-        @device.write_single(@reg_op_mode, mode)
-        wait_for_mode_ready(mode)
+        GenServer.call(name, {:write_burst, @reg_op_mode, <<mode::8>>})
+        wait_for_mode_ready(name, mode)
     end
   end
 
-  defp get_mode do
-    {:ok, byte} = @device.read_single(@reg_op_mode)
+  defp get_mode(name) do
+    {:ok, <<byte>>} = GenServer.call(name, {:read_burst, @reg_op_mode, 1})
     byte
   end
 
-  defp wait_for_mode(mode) do
+  defp wait_for_mode(name, mode) do
     mode = Map.get(@modes, mode)
-    _wait_for_mode(mode)
+    _wait_for_mode(name, mode)
   end
 
-  defp _wait_for_mode(mode) do
-    if get_mode() != mode do
+  defp _wait_for_mode(name, mode) do
+    if get_mode(name) != mode do
       :timer.sleep(1)
-      _wait_for_mode(mode)
+      _wait_for_mode(name, mode)
     end
   end
 
@@ -172,31 +188,31 @@ defmodule RFM69 do
     exit_condition_fifo_empty:      0x04,
     intermediate_mode_tx:           0x03
   }
-  defp set_auto_modes(modes) do
+  defp set_auto_modes(name, modes) do
     register_value =
       modes
       |> Enum.map(fn mode -> @auto_modes[mode] end)
       |> Enum.reduce(0x00, &(&1 ||| &2))
 
-    @device.write_single(@reg_auto_modes, register_value)
+    GenServer.call(name, {:write_burst, @reg_auto_modes, <<register_value::8>>})
   end
 
   @reg_irq_flags1 0x27
   @mode_ready     0x80
-  defp wait_for_mode_ready(mode) do
-    {:ok, current_mode} = @device.read_single(@reg_op_mode)
-    {:ok, irq_flags1} = @device.read_single(@reg_irq_flags1)
+  defp wait_for_mode_ready(name, mode) do
+    {:ok, <<current_mode>>} = GenServer.call(name, {:read_burst, @reg_op_mode, 1})
+    {:ok, <<irq_flags1>>} = GenServer.call(name, {:read_burst, @reg_irq_flags1, 1})
     mode_ready = (irq_flags1 &&& @mode_ready) != 0x00
 
     case current_mode == mode && mode_ready do
       true -> true
-      false -> wait_for_mode_ready(mode)
+      false -> wait_for_mode_ready(name, mode)
     end
   end
 
   @reg_rssi_val 0x24
-  defp read_rssi do
-    {:ok, <<raw_rssi::8>>} = @device.read_burst(@reg_rssi_val, 1)
+  defp read_rssi(name) do
+    {:ok, <<raw_rssi::8>>} = GenServer.call(name, {:read_burst, @reg_rssi_val, 1})
     -1 * trunc(raw_rssi) / 2
   end
 end

--- a/lib/rfm69/device.ex
+++ b/lib/rfm69/device.ex
@@ -11,6 +11,9 @@ defmodule RFM69.Device do
   alias ElixirALE.{GPIO, SPI}
   alias RFM69.Configuration
 
+  defstruct name: nil, device: nil, reset_pin: nil, interrupt_pin: nil
+  # @type t :: %RFM69.Device{​name: String.t, ​device:​ String.t, reset_pin: integer, interrupt_pin: integer}
+
   @configuration_start 0x01
   @hardware_version 0x10
 
@@ -18,8 +21,8 @@ defmodule RFM69.Device do
   Accepts the SPI device (eg "spidev0.0"), the reset and interrupt GPIO pin numbers and initializes communication with
   the RFM69 chip.
   """
-  def start_link(spi_device, reset_pin, interrupt_pin) do
-    GenServer.start_link(__MODULE__, [spi_device, reset_pin, interrupt_pin], name: __MODULE__)
+  def start_link(%RFM69.Device{name: name, device: device, reset_pin: reset_pin, interrupt_pin: interrupt_pin}) do
+    GenServer.start_link(__MODULE__, [device, reset_pin, interrupt_pin], name: name)
   end
 
   @doc """
@@ -40,82 +43,71 @@ defmodule RFM69.Device do
     end
   end
 
-  @doc """
-  Read burst operations happen similarly to `write_burst`, where the first byte is the register location, and each
-  subsequent byte sent (the value of the tx byte doesn't matter) results in a byte read with the value of that register
-  location using the same auto-incrementing as in writes.
-  """
-  @spec read_burst(byte, pos_integer) :: {:ok, binary}
-  def read_burst(location, byte_count) do
-    GenServer.call(__MODULE__, {:read_burst, location, byte_count})
+  def chip_present?(%RFM69.Device{device: device, reset_pin: reset_pin, interrupt_pin: interrupt_pin}) do
+    case SPI.start_link(device, speed_hz: 6_000_000) do
+      {:ok, spi_pid} ->
+        found = {:ok, <<0x24>>} == _read_burst(spi_pid, @hardware_version, 1)
+        SPI.release(spi_pid)
+        found
+      error -> false
+    end
   end
 
-  @doc """
-  Read single is a subtype of `read_burst` where only the location byte and a "don't care" byte are sent in the frame
-  and the second byte returned is the register value.
-  """
-  @spec read_single(byte) :: {:ok, byte}
-  def read_single(location) do
-    {:ok, <<value::8>>} = read_burst(location, 1)
-    {:ok, value}
-  end
+  # @doc """
+  # Read burst operations happen similarly to `write_burst`, where the first byte is the register location, and each
+  # subsequent byte sent (the value of the tx byte doesn't matter) results in a byte read with the value of that register
+  # location using the same auto-incrementing as in writes.
+  # """
+  # @spec read_burst(byte, pos_integer) :: {:ok, binary}
+  # def read_burst(location, byte_count) do
+  #   GenServer.call(__MODULE__, {:read_burst, location, byte_count})
+  # end
 
-  @doc """
-  Writing to one or more configuration register locations is done via a "write burst", where the first byte transferred
-  over SPI is the location logically ORed with 0x80 (the write bit), the second byte is the value for that register
-  location, and each subsequent sent byte is stored in the proceeding register locations. The RFM69 chip auto-increments
-  the register location for each byte so that a single frame of bytes can write the entire register configuration.
-  """
-  @spec write_burst(byte, binary) :: :ok
-  def write_burst(location, data), do: GenServer.call(__MODULE__, {:write_burst, location, data})
+  # @doc """
+  # Read single is a subtype of `read_burst` where only the location byte and a "don't care" byte are sent in the frame
+  # and the second byte returned is the register value.
+  # """
+  # @spec read_single(byte) :: {:ok, byte}
+  # def read_single(location) do
+  #   {:ok, <<value::8>>} = read_burst(location, 1)
+  #   {:ok, value}
+  # end
 
-  @doc """
-  Write single is a subtype of `write_burst` where only the location byte and a single value byte are sent in the frame.
-  """
-  @spec write_single(byte, byte) :: :ok
-  def write_single(location, data), do: write_burst(location, <<data::8>>)
+  # @doc """
+  # Writing to one or more configuration register locations is done via a "write burst", where the first byte transferred
+  # over SPI is the location logically ORed with 0x80 (the write bit), the second byte is the value for that register
+  # location, and each subsequent sent byte is stored in the proceeding register locations. The RFM69 chip auto-increments
+  # the register location for each byte so that a single frame of bytes can write the entire register configuration.
+  # """
+  # @spec write_burst(byte, binary) :: :ok
+  # def write_burst(location, data), do: GenServer.call(__MODULE__, {:write_burst, location, data})
 
-  @doc """
-  Sets the reset GPIO pin high long enough to power cycle the RFM69 chip
-  """
-  @spec reset() :: :ok
-  def reset, do: GenServer.call(__MODULE__, {:reset})
+  # @doc """
+  # Write single is a subtype of `write_burst` where only the location byte and a single value byte are sent in the frame.
+  # """
+  # @spec write_single(byte, byte) :: :ok
+  # def write_single(location, data), do: write_burst(location, <<data::8>>)
 
-  @doc """
-  Sets the receive pin interrupt so that the next incoming packet triggers an `{:ok, :interrupt_received}` message to
-  the caller so that the fifo buffer can be processed to decode the packet.
-  """
-  @spec await_interrupt() :: :ok
-  def await_interrupt, do: GenServer.call(__MODULE__, {:await_interrupt})
+  # @doc """
+  # Sets the reset GPIO pin high long enough to power cycle the RFM69 chip
+  # """
+  # @spec reset() :: :ok
+  # def reset, do: GenServer.call(__MODULE__, {:reset})
 
-  @doc """
-  Cancels the receive pin interrupt. The interrupt is canceled under normal conditions when a response message is
-  triggered, but in the case of a timeout where the caller no longer has interest in the next packet, this function can
-  be used.
-  """
-  @spec cancel_interrupt() :: :ok
-  def cancel_interrupt, do: GenServer.call(__MODULE__, {:cancel_interrupt})
+  # @doc """
+  # Sets the receive pin interrupt so that the next incoming packet triggers an `{:ok, :interrupt_received}` message to
+  # the caller so that the fifo buffer can be processed to decode the packet.
+  # """
+  # @spec await_interrupt() :: :ok
+  # def await_interrupt, do: GenServer.call(__MODULE__, {:await_interrupt})
 
-  @doc """
-  Writes a full configuration struct to the registers on the chip.
-  """
-  @spec write_configuration(Configuration.t) :: :ok
-  def write_configuration(rf_config = %Configuration{}) do
-    configuration_bytes = Configuration.to_binary(rf_config)
-    :ok = write_burst(@configuration_start, configuration_bytes)
-  end
-
-  @frf_location 0x07
-  @doc """
-  Sets the frequency to the appropriate chip registers
-  """
-  @spec write_frequency(pos_integer) :: {:ok}
-  def write_frequency(frequency_in_hz) do
-    register_values = Configuration.frequency_to_registers(frequency_in_hz)
-    register_bytes = <<register_values::24>>
-    :ok = write_burst(@frf_location, register_bytes)
-    {:ok}
-  end
+  # @doc """
+  # Cancels the receive pin interrupt. The interrupt is canceled under normal conditions when a response message is
+  # triggered, but in the case of a timeout where the caller no longer has interest in the next packet, this function can
+  # be used.
+  # """
+  # @spec cancel_interrupt() :: :ok
+  # def cancel_interrupt, do: GenServer.call(__MODULE__, {:cancel_interrupt})
 
   def handle_call({:reset}, _from, state = %{reset_pid: reset_pid}) do
     GPIO.write(reset_pid, 1)


### PR DESCRIPTION
This PR introduces several features. There is now a struct for the Device that holds the relevant information for starting the SPI link. `start_link` should now be called with the struct. `start_link` will alias the process with the atom given in the name key of the struct, so it's possible to start more than one chip process at one time now.

When calling any of the public functions on the `RFM69` module, the first parameter is the Device struct that was used to call `start_link`. This allows the RFM69 module to use the name key of the struct to communicate with the process, and also allows upstream libraries to more easily define a protocol for the chip functions using the structs.

Additionally, a new `chip_present?` function has been added that will attempt to detect whether the chip is responding using the given struct's pin and device configuration.

In some ways the library has gotten more complex because of these changes, but it solves several longstanding problems with supporting different kinds of serial devices and chips, and this should pave the way to making some simplifications in the design for developers using this package as the simplifications become clearer.